### PR TITLE
fix: fix create playlist payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,8 @@ curl -X PUT --location 'http://localhost:8080/playlists' \
       --header 'Content-Type: application/json' \
 --data '{"artists":[{"name": "<artist_name>"}],"playlist":{"name":"<playlist_name>","description":"<playlist_description>","isPublic":<true_false>}}
 ```
+
+> [!IMPORTANT]
+> `public` refers to whether the playlist is publicly shown in your profile.
+> However, the playlist is still publicly available given the playlist id.
+> See [this](https://community.spotify.com/t5/Spotify-for-Developers/Api-to-create-a-private-playlist-doesn-t-work/td-p/5407807) for more details.

--- a/internal/playlist/spotify/spotify_playlist.go
+++ b/internal/playlist/spotify/spotify_playlist.go
@@ -3,5 +3,5 @@ package spotify
 type SpotifyPlaylist struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
-	IsPublic    bool   `json:"is_public"`
+	IsPublic    bool   `json:"public"`
 }

--- a/internal/playlist/spotify/spotify_playlist_repository_test.go
+++ b/internal/playlist/spotify/spotify_playlist_repository_test.go
@@ -123,7 +123,7 @@ func createPlaylistHttpOptions() httpsender.HTTPRequestOptions {
 	url := fmt.Sprintf("https://api.spotify.com/v1/users/%s/playlists", userId)
 	options := httpsender.NewHTTPRequestOptions(url, httpsender.POST, 201)
 	options.SetHeaders(authHeaders())
-	createPlaylistBody := []byte(`{"name":"my-playlist","description":"some playlist","is_public":false}`)
+	createPlaylistBody := []byte(`{"name":"my-playlist","description":"some playlist","public":false}`)
 	options.SetBody(createPlaylistBody)
 	return options
 }


### PR DESCRIPTION
# Description

Fixes the `public` payload attribute. See [API docs](https://developer.spotify.com/documentation/web-api/reference/create-playlist) for more information.

Also adds a disclaimer on how to properly interpret the `isPublic` option in our endpoint, as it can be a source of confusion. We are planning a task to change the API naming to reflect the actual behavior.
