### PR TITLE
chore: FW-97 Add restrictions to mitigate rate limit impact

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -47,6 +47,7 @@ func main() {
 	setlistfmApiKey := GetEnvStringOrFail("FESTWRAP_SETLISTFM_APIKEY")
 	maxSetlistFMNumSearchPages := GetEnvWithDefaultOrFail[int]("FESTWRAP_SETLISTFM_NUM_SEARCH_PAGES", 3)
 	maxUpdateArtists := GetEnvWithDefaultOrFail[int]("FESTWRAP_MAX_UPDATE_ARTISTS", 5)
+	addSetlistSleepMs := GetEnvWithDefaultOrFail[int]("FESTWRAP_ADD_SETLIST_SLEEP_MS", 550)
 
 	slogLogger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	logger := logging.NewBaseLogger(slogLogger)
@@ -84,10 +85,12 @@ func main() {
 	)
 	existingPlaylistUpdateHandler := playlisthandler.NewUpdateExistingPlaylistHandler("playlistId", &playlistService, logger)
 	existingPlaylistUpdateHandler.SetMaxArtists(maxUpdateArtists)
+	existingPlaylistUpdateHandler.SetAddSetlistSleep(addSetlistSleepMs)
 	mux.HandleFunc("/playlists/{playlistId}", existingPlaylistUpdateHandler.ServeHTTP)
 
 	newPlaylistUpdateHandler := playlisthandler.NewUpdateNewPlaylistHandler(&playlistService, logger)
 	newPlaylistUpdateHandler.SetMaxArtists(maxUpdateArtists)
+	newPlaylistUpdateHandler.SetAddSetlistSleep(addSetlistSleepMs)
 	mux.HandleFunc(
 		"/playlists",
 		middleware.NewUserIdMiddleware(&newPlaylistUpdateHandler, userRepository).ServeHTTP,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -46,6 +46,7 @@ func main() {
 	timeoutSeconds := GetEnvWithDefaultOrFail[int]("FESTWRAP_TIMEOUT_SECONDS", 5)
 	setlistfmApiKey := GetEnvStringOrFail("FESTWRAP_SETLISTFM_APIKEY")
 	maxSetlistFMNumSearchPages := GetEnvWithDefaultOrFail[int]("FESTWRAP_SETLISTFM_NUM_SEARCH_PAGES", 3)
+	maxUpdateArtists := GetEnvWithDefaultOrFail[int]("FESTWRAP_MAX_UPDATE_ARTISTS", 5)
 
 	slogLogger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	logger := logging.NewBaseLogger(slogLogger)
@@ -82,9 +83,11 @@ func main() {
 		songRepository,
 	)
 	existingPlaylistUpdateHandler := playlisthandler.NewUpdateExistingPlaylistHandler("playlistId", &playlistService, logger)
+	existingPlaylistUpdateHandler.SetMaxArtists(maxUpdateArtists)
 	mux.HandleFunc("/playlists/{playlistId}", existingPlaylistUpdateHandler.ServeHTTP)
 
 	newPlaylistUpdateHandler := playlisthandler.NewUpdateNewPlaylistHandler(&playlistService, logger)
+	newPlaylistUpdateHandler.SetMaxArtists(maxUpdateArtists)
 	mux.HandleFunc(
 		"/playlists",
 		middleware.NewUserIdMiddleware(&newPlaylistUpdateHandler, userRepository).ServeHTTP,


### PR DESCRIPTION
# Context

Setlistfm API has a low rate limit (2 req/s). To avoid easily hitting the limit, we are adding a delay between setlists. By doing so, we force pairs of consecutive requests to happen in separate seconds.

We are also reading the maximum amout of artists for playlist updates from the environment variables.