### PR TITLE
chore: FW-76 Restrict http methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ make run-tests
 To run the API locally, you can type:
 
 ```shell
-go run cmd/main.go
+go run ./cmd
 ```
 
 ### Run the app container

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"festwrap/internal/env"
+	"log"
+	"os"
+)
+
+type Config struct {
+	Port                       string
+	MaxConnsPerHost            int
+	TimeoutSeconds             int
+	SetlistfmApiKey            string
+	MaxSetlistFMNumSearchPages int
+	MaxUpdateArtists           int
+	AddSetlistSleepMs          int
+}
+
+func ReadConfig() Config {
+	return Config{
+		Port:                       GetEnvWithDefaultOrFail[string]("FESTWRAP_PORT", "8080"),
+		MaxConnsPerHost:            GetEnvWithDefaultOrFail[int]("FESTWRAP_MAX_CONNS_PER_HOST", 10),
+		TimeoutSeconds:             GetEnvWithDefaultOrFail[int]("FESTWRAP_TIMEOUT_SECONDS", 5),
+		SetlistfmApiKey:            GetEnvStringOrFail("FESTWRAP_SETLISTFM_APIKEY"),
+		MaxSetlistFMNumSearchPages: GetEnvWithDefaultOrFail[int]("FESTWRAP_SETLISTFM_NUM_SEARCH_PAGES", 3),
+		MaxUpdateArtists:           GetEnvWithDefaultOrFail[int]("FESTWRAP_MAX_UPDATE_ARTISTS", 5),
+		AddSetlistSleepMs:          GetEnvWithDefaultOrFail[int]("FESTWRAP_ADD_SETLIST_SLEEP_MS", 550),
+	}
+}
+
+func GetEnvWithDefaultOrFail[T env.EnvValue](key string, defaultValue T) T {
+	variable, err := env.GetEnvWithDefault[T](key, defaultValue)
+	if err != nil {
+		log.Fatalf("Could not read variable %s", key)
+	}
+	return variable
+}
+
+func GetEnvStringOrFail(key string) string {
+	variable := os.Getenv(key)
+	if variable == "" {
+		log.Fatalf("Could not read variable %s", key)
+	}
+	return variable
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -62,6 +62,7 @@ func main() {
 	httpSender := httpsender.NewBaseHTTPRequestSender(&baseHttpClient)
 
 	mux := mux.NewRouter()
+	mux.Use(middleware.NewAuthTokenExtractor().Middleware)
 
 	artistRepository := spotifyArtists.NewSpotifyArtistRepository(&httpSender)
 	artistSearcher := search.NewFunctionSearcher(artistRepository.SearchArtist)
@@ -100,10 +101,9 @@ func main() {
 		middleware.NewUserIdMiddleware(&newPlaylistUpdateHandler, userRepository).ServeHTTP,
 	).Methods(http.MethodPost)
 
-	wrappedMux := middleware.NewAuthTokenMiddleware(mux)
 	server := &http.Server{
 		Addr:    fmt.Sprintf(":%s", port),
-		Handler: wrappedMux,
+		Handler: mux,
 	}
 
 	server.ListenAndServe()

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,12 +23,15 @@ import (
 	"github.com/gorilla/mux"
 )
 
+func setupLogger() logging.Logger {
+	slogLogger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	return logging.NewBaseLogger(slogLogger)
+}
+
 func main() {
 
 	config := ReadConfig()
-
-	slogLogger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
-	logger := logging.NewBaseLogger(slogLogger)
+	logger := setupLogger()
 
 	httpClient := &http.Client{
 		Transport: &http.Transport{MaxConnsPerHost: config.MaxConnsPerHost},

--- a/cmd/middleware/auth_token_test.go
+++ b/cmd/middleware/auth_token_test.go
@@ -24,44 +24,44 @@ func defaultTokenKey() types.ContextKey {
 	return tokenKey
 }
 
-func tokenAuthMiddlewareTestSetup() (AuthTokenMiddleware, *http.Request, *httptest.ResponseRecorder) {
-	middleware := NewAuthTokenMiddleware(GetTokenHandler{})
+func tokenAuthExtractorTestSetup() (AuthTokenExtractor, *http.Request, *httptest.ResponseRecorder) {
+	middleware := NewAuthTokenExtractor()
 	request := httptest.NewRequest("GET", "http://example.com", nil)
 	writer := httptest.NewRecorder()
 	return middleware, request, writer
 }
 
 func TestBadRequestErrorOnMissingAuthHeader(t *testing.T) {
-	middleware, request, writer := tokenAuthMiddlewareTestSetup()
+	extractor, request, writer := tokenAuthExtractorTestSetup()
 
-	middleware.ServeHTTP(writer, request)
+	extractor.Middleware(GetTokenHandler{}).ServeHTTP(writer, request)
 
 	assert.Equal(t, http.StatusBadRequest, writer.Code)
 }
 
 func TestUnprocessableEntityErrorOnWronglyFormattedAuthHeader(t *testing.T) {
-	middleware, request, writer := tokenAuthMiddlewareTestSetup()
+	extractor, request, writer := tokenAuthExtractorTestSetup()
 	request.Header.Set("Authorization", "something")
 
-	middleware.ServeHTTP(writer, request)
+	extractor.Middleware(GetTokenHandler{}).ServeHTTP(writer, request)
 
 	assert.Equal(t, http.StatusUnprocessableEntity, writer.Code)
 }
 
 func TestTokenIsPlacedInExpectedContextKey(t *testing.T) {
-	middleware, request, writer := tokenAuthMiddlewareTestSetup()
+	extractor, request, writer := tokenAuthExtractorTestSetup()
 	request.Header.Set("Authorization", "Bearer 1234")
 
-	middleware.ServeHTTP(writer, request)
+	extractor.Middleware(GetTokenHandler{}).ServeHTTP(writer, request)
 
 	assert.Equal(t, "1234", writer.Body.String())
 }
 
 func TestMiddlewareReturnsStatusCodeofTheHandler(t *testing.T) {
-	middleware, request, writer := tokenAuthMiddlewareTestSetup()
+	extractor, request, writer := tokenAuthExtractorTestSetup()
 	request.Header.Set("Authorization", "Bearer 1234")
 
-	middleware.ServeHTTP(writer, request)
+	extractor.Middleware(GetTokenHandler{}).ServeHTTP(writer, request)
 
 	assert.Equal(t, http.StatusAccepted, writer.Code)
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require github.com/stretchr/testify v1.10.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=

--- a/internal/playlist/update_builders/playlist_update_builders.go
+++ b/internal/playlist/update_builders/playlist_update_builders.go
@@ -8,6 +8,8 @@ import (
 
 	"festwrap/internal/playlist"
 	"festwrap/internal/serialization"
+
+	"github.com/gorilla/mux"
 )
 
 type PlaylistUpdateBuilder interface {
@@ -32,7 +34,7 @@ func NewExistingPlaylistUpdateBuilder(pathId string) ExistingPlaylistUpdateBuild
 }
 
 func (b *ExistingPlaylistUpdateBuilder) Build(request *http.Request) (playlist.PlaylistUpdate, error) {
-	playlistId := request.PathValue(b.pathId)
+	playlistId := mux.Vars(request)[b.pathId]
 	if playlistId == "" {
 		return playlist.PlaylistUpdate{}, fmt.Errorf("could not find playlist id in %s", b.pathId)
 	}


### PR DESCRIPTION
# Description

Restricts entrypoints to the expected specific HTTP methods. Returns 405 otherwise.

Took the chance to introduce small scouting, to help cleaning the main script.

# Testing

We start the application:

```shell
FESTWRAP_SETLISTFM_APIKEY="abcde" go run ./cm
```

Then we query:

```
curl "http://localhost:8080/artists/search?name=Iron" -vvv
* Host localhost:8080 was resolved.
* IPv6: ::1
* IPv4: *********
*   Trying [::1]:8080...
* Connected to localhost (::1) port 8080
> GET /artists/search?name=Iron HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 400 Bad Request
< Content-Type: text/plain; charset=utf-8
< X-Content-Type-Options: nosniff
< Date: Wed, 21 May 2025 07:28:46 GMT
< Content-Length: 29
< 
Missing authorization header
* Connection #0 to host localhost left intact
```

We get a 400 error, which is expected as we did not include the auth header.

If we query the same using a POST, instead, we get a 405 error:

```
curl -X POST "http://localhost:8080/artists/search?name=Iron" -vvvv
* Host localhost:8080 was resolved.
* IPv6: ::1
* IPv4: *********
*   Trying [::1]:8080...
* Connected to localhost (::1) port 8080
> POST /artists/search?name=Iron HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 405 Method Not Allowed
< Date: Wed, 21 May 2025 07:27:50 GMT
< Content-Length: 0
< 
* Connection #0 to host localhost left intact
* 
* ```