### PR TITLE
feat: FW-162 limit artist name length

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -10,7 +10,7 @@ type Config struct {
 	Port                       string
 	MaxConnsPerHost            int
 	MaxSetlistFMNumSearchPages int
-	MaxUpdateArtists           int
+	MaxCreateArtists           int
 	AddSetlistSleepMs          int
 	NextPageSleepMs            int
 	HttpClientTimeoutSeconds   int
@@ -28,7 +28,7 @@ func ReadConfig() Config {
 		MaxConnsPerHost:            GetEnvWithDefaultOrFail[int]("FESTWRAP_MAX_CONNS_PER_HOST", 10),
 		SetlistfmApiKey:            GetEnvStringOrFail("FESTWRAP_SETLISTFM_APIKEY"),
 		MaxSetlistFMNumSearchPages: GetEnvWithDefaultOrFail[int]("FESTWRAP_SETLISTFM_NUM_SEARCH_PAGES", 3),
-		MaxUpdateArtists:           GetEnvWithDefaultOrFail[int]("FESTWRAP_MAX_UPDATE_ARTISTS", 5),
+		MaxCreateArtists:           GetEnvWithDefaultOrFail[int]("FESTWRAP_MAX_CREATE_ARTISTS", 5),
 		AddSetlistSleepMs:          GetEnvWithDefaultOrFail[int]("FESTWRAP_ADD_SETLIST_SLEEP_MS", 550),
 		NextPageSleepMs:            GetEnvWithDefaultOrFail[int]("FESTWRAP_GET_SETLIST_NEXT_PAGE_SLEEP_MS", 550),
 		HttpClientTimeoutSeconds:   GetEnvWithDefaultOrFail[int]("FESTWRAP_HTTP_CLIENT_TIMEOUT_S", 5),

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	MaxConnsPerHost            int
 	MaxSetlistFMNumSearchPages int
 	MaxCreateArtists           int
+	MaxArtistNameLength        int
 	AddSetlistSleepMs          int
 	NextPageSleepMs            int
 	HttpClientTimeoutSeconds   int
@@ -29,6 +30,7 @@ func ReadConfig() Config {
 		SetlistfmApiKey:            GetEnvStringOrFail("FESTWRAP_SETLISTFM_APIKEY"),
 		MaxSetlistFMNumSearchPages: GetEnvWithDefaultOrFail[int]("FESTWRAP_SETLISTFM_NUM_SEARCH_PAGES", 3),
 		MaxCreateArtists:           GetEnvWithDefaultOrFail[int]("FESTWRAP_MAX_CREATE_ARTISTS", 5),
+		MaxArtistNameLength:        GetEnvWithDefaultOrFail[int]("FESTWRAP_MAX_ARTIST_NAME_LENGTH", 50),
 		AddSetlistSleepMs:          GetEnvWithDefaultOrFail[int]("FESTWRAP_ADD_SETLIST_SLEEP_MS", 550),
 		NextPageSleepMs:            GetEnvWithDefaultOrFail[int]("FESTWRAP_GET_SETLIST_NEXT_PAGE_SLEEP_MS", 550),
 		HttpClientTimeoutSeconds:   GetEnvWithDefaultOrFail[int]("FESTWRAP_HTTP_CLIENT_TIMEOUT_S", 5),

--- a/cmd/handler/search/search_test.go
+++ b/cmd/handler/search/search_test.go
@@ -87,6 +87,16 @@ func TestBadRequestIfNameNotProvided(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, writer.Code)
 }
 
+func TestBadRequestIfNameTooLong(t *testing.T) {
+	params := defaultQueryParams()
+	writer, request, handler := setup(t, params)
+	handler.SetMaxNameLength(1)
+
+	handler.ServeHTTP(writer, request)
+
+	assert.Equal(t, http.StatusBadRequest, writer.Code)
+}
+
 func TestLimitStatusCodeDependingOnValue(t *testing.T) {
 	tests := map[string]struct {
 		limit    string

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -72,7 +72,7 @@ func main() {
 	)
 	playlistService.SetAddSetlistSleep(config.AddSetlistSleepMs)
 	newPlaylistUpdateHandler := playlisthandler.NewCreatePlaylistHandler(&playlistService, logger)
-	newPlaylistUpdateHandler.SetMaxArtists(config.MaxUpdateArtists)
+	newPlaylistUpdateHandler.SetMaxArtists(config.MaxCreateArtists)
 	userRepository := spotifyusers.NewSpotifyUserRepository(httpSender)
 	userIdExtractor := middleware.NewUserIdExtractor(userRepository, logger)
 	mux.Handle(

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -56,6 +56,7 @@ func main() {
 	artistRepository := spotifyArtists.NewSpotifyArtistRepository(httpSender)
 	artistSearcher := search.NewFunctionSearcher(artistRepository.SearchArtist)
 	searchArtistsHandler := search.NewSearchHandler(&artistSearcher, "artists", logger)
+	searchArtistsHandler.SetMaxNameLength(config.MaxArtistNameLength)
 	mux.HandleFunc("/artists/search", searchArtistsHandler.ServeHTTP).Methods(http.MethodGet)
 
 	// Set create new playlist endpoint
@@ -73,6 +74,7 @@ func main() {
 	playlistService.SetAddSetlistSleep(config.AddSetlistSleepMs)
 	newPlaylistUpdateHandler := playlisthandler.NewCreatePlaylistHandler(&playlistService, logger)
 	newPlaylistUpdateHandler.SetMaxArtists(config.MaxCreateArtists)
+	newPlaylistUpdateHandler.SetMaxArtistNameLength(config.MaxArtistNameLength)
 	userRepository := spotifyusers.NewSpotifyUserRepository(httpSender)
 	userIdExtractor := middleware.NewUserIdExtractor(userRepository, logger)
 	mux.Handle(


### PR DESCRIPTION
# Description

Limits the length of the artist names. This is especially important in the create endpoint: given that we use edit distance to rank setlists, artist name length can become an attack surface to drain the server resources.